### PR TITLE
Wissenschaftlichen Schreib-Bot mit Harvard-Zitierstil implementieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# Codex – Agentisches RAG-System
+# Codex – Agentisches RAG-System & Wissenschaftliches Schreiben
 
 Codex ist ein containerisiertes Retrieval-Augmented-Generation-System (RAG), das heterogene
 Dokumente via [Docling](https://github.com/docling-project/docling) in Markdown konvertiert, mit
-OpenAI-Embeddings indiziert und Antworten über Anthropic oder OpenAI generiert. Eine minimale
-Streamlit-Oberfläche erlaubt das Hochladen von Dokumenten, das Starten der Ingestion und das Stellen
-von Fragen mit Quellenangaben.
+OpenAI-Embeddings indiziert und Antworten über Anthropic oder OpenAI generiert.
+
+**Neu: Wissenschaftlicher Schreib-Bot** – Generiere automatisch wissenschaftliche Paper-Sektionen
+(Abstract, Einleitung, Literaturübersicht, Methodik, Ergebnisse, Diskussion, Schlussfolgerung)
+mit korrekten **Harvard-Zitationen** basierend auf deiner hochgeladenen Literatur.
+
+Eine minimale Streamlit-Oberfläche bietet zwei Modi:
+- **Q&A-Modus**: Stelle Fragen an deine Dokumente
+- **Wissenschaftliches Schreiben**: Generiere Paper-Sektionen mit automatischen Zitationen
 
 ## Architektur
 
@@ -46,8 +52,12 @@ von Fragen mit Quellenangaben.
 
 3. **Weboberfläche öffnen** – [http://localhost:8501](http://localhost:8501)
 
-4. **Dokumente hochladen** und „Ingest starten“ klicken. Anschließend Fragen im unteren Bereich
-   stellen. Quellen werden im Expander angezeigt.
+4. **Dokumente hochladen** und „Ingest starten" klicken.
+
+5. **Q&A-Modus**: Stelle Fragen an deine Dokumente. Quellen werden mit Scores angezeigt.
+
+6. **Wissenschaftliches Schreiben**: Wähle eine Paper-Sektion (z.B. "Einleitung"), gib dein
+   Forschungsthema ein und generiere einen wissenschaftlichen Text mit Harvard-Zitationen.
 
 ### Datenablage
 
@@ -63,7 +73,8 @@ von Fragen mit Quellenangaben.
 
 ## Module
 
-* `rag_agent/app.py` – Streamlit-GUI.
+* `rag_agent/app.py` – Streamlit-GUI mit Q&A und wissenschaftlichem Schreiben.
+* `rag_agent/scientific_writing.py` – **NEU**: Wissenschaftlicher Schreib-Bot mit Harvard-Zitationen.
 * `rag_agent/ingest.py` – Upload, Docling-Konvertierung, Chunking, Embedding.
 * `rag_agent/embeddings.py` – OpenAI Embedding-Client.
 * `rag_agent/rerank.py` – LLM-basierter Reranker (OpenAI).
@@ -84,6 +95,33 @@ von Fragen mit Quellenangaben.
 
 * Für lokale Tests empfiehlt sich eine Postgres-Instanz mit pgvector (z. B. via Docker).
 
+## Wissenschaftliches Schreiben
+
+Der neue wissenschaftliche Schreib-Modus bietet:
+
+### Verfügbare Paper-Sektionen
+* **Abstract/Zusammenfassung** (150-250 Wörter)
+* **Einleitung** – Hintergrund, Forschungsfrage, Zielsetzung
+* **Literaturübersicht** – Systematischer Überblick über den Forschungsstand
+* **Methodik** – Detaillierte Beschreibung des methodischen Vorgehens
+* **Ergebnisse** – Objektive Präsentation der Befunde
+* **Diskussion** – Interpretation und Einordnung der Ergebnisse
+* **Schlussfolgerung** – Zusammenfassung und Ausblick
+
+### Features
+* **Harvard-Zitierstil**: Automatische In-Text-Zitationen (Autor, Jahr) und Literaturverzeichnis
+* **Quellenbasiert**: Alle Aussagen werden durch hochgeladene Dokumente gestützt
+* **Wissenschaftlicher Stil**: Objektive, präzise Formulierungen mit Fachterminologie
+* **Anpassbar**: Wähle die Anzahl der Quellen (3-15) für jeden generierten Text
+* **Deutsche Sprache**: Alle Texte werden auf Deutsch generiert
+
+### Workflow
+1. Lade wissenschaftliche Literatur hoch (PDF, DOCX, etc.)
+2. Wähle die gewünschte Paper-Sektion
+3. Gib dein Forschungsthema oder deine Fragestellung ein
+4. Der Bot generiert einen strukturierten wissenschaftlichen Text
+5. Erhalte automatisch ein Harvard-Literaturverzeichnis
+
 ## Bekannte Einschränkungen
 
 * Die Datenbank-Tabelle ist auf Embeddings mit 3072 Dimensionen ausgelegt (`text-embedding-3-large`).
@@ -91,6 +129,8 @@ von Fragen mit Quellenangaben.
 * Docling muss im Container installiert sein (wird über `requirements.txt` erledigt), benötigt aber
   zusätzliche Systemabhängigkeiten für OCR (z. B. `tesseract-ocr`).
 * Ohne gültige API-Keys werden im UI Hinweise angezeigt; Funktionen sind deaktiviert.
+* **Wissenschaftliches Schreiben**: Die Qualität hängt stark von der hochgeladenen Literatur ab.
+  Für beste Ergebnisse sollten relevante, hochwertige wissenschaftliche Quellen verwendet werden.
 
 ## Lizenz
 

--- a/rag_agent/app.py
+++ b/rag_agent/app.py
@@ -9,6 +9,11 @@ import streamlit as st
 
 from .ingest import ingest_paths, secure_filename
 from .qa import answer_question
+from .scientific_writing import (
+    PaperSection,
+    SECTION_NAMES_DE,
+    generate_scientific_section,
+)
 from .settings import settings
 from .storage import chunk_count, init_db
 
@@ -40,49 +45,153 @@ def main() -> None:
     st.set_page_config(page_title="Codex", layout="wide")
     init_db()
 
-    st.title("Codex – Dokumente fragen, Antworten erhalten")
+    st.title("Codex – RAG-System & Wissenschaftliches Schreiben")
     st.caption("Agentisches RAG-System mit Docling, OpenAI und Anthropic")
 
     _status_messages()
 
-    st.subheader("Daten importieren")
-    uploaded_files = st.file_uploader(
-        "Unterstützte Formate: PDF, DOCX, PPTX, HTML, PNG/JPG, MD/TXT",
-        accept_multiple_files=True,
+    # Mode selection
+    mode = st.radio(
+        "Modus auswählen:",
+        ["📚 Q&A: Fragen beantworten", "✍️ Wissenschaftliches Schreiben"],
+        horizontal=True,
     )
 
-    if st.button("Ingest starten"):
-        if not uploaded_files:
-            st.warning("Bitte zuerst Dateien hochladen.")
-        else:
-            with st.spinner("Ingestion läuft…"):
-                paths = _save_uploaded_files(uploaded_files)
-                results = ingest_paths(paths)
-            if results:
-                chunk_total = sum(result.chunks for result in results)
-                st.success(f"Ingest abgeschlossen ({chunk_total} Chunks).")
+    st.divider()
+
+    # Data import section (shared by both modes)
+    with st.expander("📤 Daten importieren", expanded=(chunk_count() == 0)):
+        uploaded_files = st.file_uploader(
+            "Unterstützte Formate: PDF, DOCX, PPTX, HTML, PNG/JPG, MD/TXT",
+            accept_multiple_files=True,
+        )
+
+        if st.button("Ingest starten"):
+            if not uploaded_files:
+                st.warning("Bitte zuerst Dateien hochladen.")
             else:
-                st.error("Ingest fehlgeschlagen – Details siehe Logs.")
-
-    st.subheader("Frage beantworten")
-    question = st.text_area("Deine Frage an die Dokumente", height=120)
-    if st.button("Antwort anzeigen"):
-        if not question.strip():
-            st.warning("Bitte eine Frage eingeben.")
-        else:
-            with st.spinner("Suche nach Antworten…"):
-                try:
-                    result = answer_question(question)
-                except Exception as exc:  # pragma: no cover - UI feedback
-                    st.error(f"Fehler bei der Antwortgenerierung: {exc}")
+                with st.spinner("Ingestion läuft…"):
+                    paths = _save_uploaded_files(uploaded_files)
+                    results = ingest_paths(paths)
+                if results:
+                    chunk_total = sum(result.chunks for result in results)
+                    st.success(f"Ingest abgeschlossen ({chunk_total} Chunks).")
                 else:
-                    st.markdown(result.text)
-                    with st.expander("Verwendete Quellen", expanded=True):
-                        for source in result.sources:
-                            st.markdown(
-                                f"**{source.doc_id}#{source.chunk_id}** – Score: {source.score:.2f}\n\n{source.content}"
-                            )
+                    st.error("Ingest fehlgeschlagen – Details siehe Logs.")
 
+    st.divider()
+
+    # Q&A Mode
+    if mode == "📚 Q&A: Fragen beantworten":
+        st.subheader("Frage beantworten")
+        question = st.text_area("Deine Frage an die Dokumente", height=120)
+        if st.button("Antwort anzeigen", type="primary"):
+            if not question.strip():
+                st.warning("Bitte eine Frage eingeben.")
+            else:
+                with st.spinner("Suche nach Antworten…"):
+                    try:
+                        result = answer_question(question)
+                    except Exception as exc:  # pragma: no cover - UI feedback
+                        st.error(f"Fehler bei der Antwortgenerierung: {exc}")
+                    else:
+                        st.markdown(result.text)
+                        with st.expander("Verwendete Quellen", expanded=True):
+                            for source in result.sources:
+                                st.markdown(
+                                    f"**{source.doc_id}#{source.chunk_id}** – Score: {source.score:.2f}\n\n{source.content}"
+                                )
+
+    # Scientific Writing Mode
+    else:
+        st.subheader("✍️ Wissenschaftliches Schreiben")
+        st.markdown(
+            "Generiere wissenschaftliche Texte mit automatischen Zitationen im **Harvard-Stil** "
+            "basierend auf deinen hochgeladenen Dokumenten."
+        )
+
+        col1, col2 = st.columns([2, 1])
+
+        with col1:
+            topic = st.text_area(
+                "Forschungsthema / Fragestellung",
+                height=100,
+                placeholder="z.B. 'Die Auswirkungen von maschinellem Lernen auf die medizinische Diagnostik'",
+            )
+
+        with col2:
+            section = st.selectbox(
+                "Paper-Sektion",
+                options=list(PaperSection),
+                format_func=lambda x: SECTION_NAMES_DE[x],
+            )
+
+            num_sources = st.slider(
+                "Anzahl Quellen",
+                min_value=3,
+                max_value=15,
+                value=8,
+                help="Wie viele Quellen sollen für die Textgenerierung verwendet werden?",
+            )
+
+        if st.button("Text generieren", type="primary"):
+            if not topic.strip():
+                st.warning("Bitte ein Forschungsthema eingeben.")
+            elif chunk_count() == 0:
+                st.error("Keine Dokumente in der Datenbank. Bitte zuerst Literatur hochladen.")
+            else:
+                with st.spinner(f"Generiere {SECTION_NAMES_DE[section]}…"):
+                    try:
+                        result = generate_scientific_section(
+                            section=section,
+                            topic=topic,
+                            num_sources=num_sources,
+                        )
+                    except Exception as exc:  # pragma: no cover - UI feedback
+                        st.error(f"Fehler bei der Textgenerierung: {exc}")
+                        logger.exception("Scientific writing generation failed")
+                    else:
+                        # Display generated text
+                        st.markdown("### Generierter Text")
+                        st.markdown(result.text)
+
+                        # Display reference list
+                        if result.reference_list:
+                            st.markdown(result.reference_list)
+
+                        # Display sources
+                        with st.expander("📚 Verwendete Quellen", expanded=False):
+                            for idx, source in enumerate(result.sources, 1):
+                                st.markdown(
+                                    f"**Quelle {idx}: {source.doc_id}#{source.chunk_id}** "
+                                    f"(Score: {source.score:.2f})"
+                                )
+                                st.text(source.content[:300] + "..." if len(source.content) > 300 else source.content)
+                                st.divider()
+
+        # Help section
+        with st.expander("ℹ️ Hilfe zum wissenschaftlichen Schreiben"):
+            st.markdown("""
+            **So funktioniert's:**
+
+            1. **Dokumente hochladen**: Laden Sie wissenschaftliche Literatur (PDFs, DOCX, etc.) hoch
+            2. **Sektion wählen**: Wählen Sie den gewünschten Abschnitt Ihres Papers
+            3. **Thema eingeben**: Beschreiben Sie Ihre Forschungsfrage oder Ihr Thema
+            4. **Text generieren**: Der Bot erstellt einen wissenschaftlichen Text mit Harvard-Zitationen
+
+            **Verfügbare Sektionen:**
+            - **Abstract**: Prägnante Zusammenfassung (150-250 Wörter)
+            - **Einleitung**: Hintergrund, Forschungsfrage, Zielsetzung
+            - **Literaturübersicht**: Systematischer Überblick über Forschungsstand
+            - **Methodik**: Detaillierte Beschreibung des methodischen Vorgehens
+            - **Ergebnisse**: Objektive Präsentation der Befunde
+            - **Diskussion**: Interpretation und Einordnung der Ergebnisse
+            - **Schlussfolgerung**: Zusammenfassung und Ausblick
+
+            **Zitierstil**: Alle Quellen werden automatisch im **Harvard-Stil** zitiert.
+            """)
+
+    st.divider()
     st.caption("Fehlermeldungen? Bitte API-Keys prüfen und Logs ansehen.")
 
 

--- a/rag_agent/scientific_writing.py
+++ b/rag_agent/scientific_writing.py
@@ -1,0 +1,325 @@
+"""Scientific writing module with Harvard citation style."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Dict
+
+from anthropic import Anthropic
+from openai import OpenAI
+
+from .embeddings import embed_texts
+from .llm import ContextChunk, _get_anthropic, _get_openai
+from .rerank import RerankCandidate, rerank
+from .retrieval import RetrievedChunk, similarity_search
+from .settings import settings
+
+
+class PaperSection(Enum):
+    """Scientific paper section types."""
+    ABSTRACT = "abstract"
+    INTRODUCTION = "introduction"
+    LITERATURE_REVIEW = "literature_review"
+    METHODOLOGY = "methodology"
+    RESULTS = "results"
+    DISCUSSION = "discussion"
+    CONCLUSION = "conclusion"
+
+
+SECTION_NAMES_DE = {
+    PaperSection.ABSTRACT: "Abstract/Zusammenfassung",
+    PaperSection.INTRODUCTION: "Einleitung",
+    PaperSection.LITERATURE_REVIEW: "Literaturübersicht",
+    PaperSection.METHODOLOGY: "Methodik",
+    PaperSection.RESULTS: "Ergebnisse",
+    PaperSection.DISCUSSION: "Diskussion",
+    PaperSection.CONCLUSION: "Schlussfolgerung",
+}
+
+
+@dataclass
+class Citation:
+    """Harvard-style citation."""
+    doc_id: str
+    chunk_id: int
+    authors: str | None = None
+    year: str | None = None
+
+    @property
+    def in_text(self) -> str:
+        """Generate in-text citation in Harvard style."""
+        if self.authors and self.year:
+            # Extract first author's last name
+            first_author = self.authors.split(',')[0].split(' et al.')[0].strip()
+            return f"({first_author}, {self.year})"
+        # Fallback to document reference
+        return f"({self.doc_id})"
+
+    @property
+    def reference(self) -> str:
+        """Generate full reference in Harvard style."""
+        if self.authors and self.year:
+            return f"{self.authors} ({self.year}). {self.doc_id}"
+        return f"{self.doc_id}"
+
+
+@dataclass
+class ScientificText:
+    """Generated scientific text with citations."""
+    text: str
+    citations: List[Citation]
+    sources: List[RetrievedChunk]
+    reference_list: str
+
+
+def _extract_metadata(chunk: RetrievedChunk) -> Dict[str, str]:
+    """Extract metadata for citations from chunk."""
+    meta = chunk.meta or {}
+    return {
+        'authors': meta.get('authors', ''),
+        'year': meta.get('year', ''),
+        'title': meta.get('title', chunk.doc_id),
+    }
+
+
+def _build_harvard_references(citations: List[Citation]) -> str:
+    """Build Harvard-style reference list."""
+    if not citations:
+        return ""
+
+    references = []
+    seen = set()
+
+    for citation in citations:
+        ref_key = f"{citation.authors}_{citation.year}"
+        if ref_key not in seen:
+            references.append(citation.reference)
+            seen.add(ref_key)
+
+    # Sort alphabetically by author
+    references.sort()
+
+    return "\n\n**Literaturverzeichnis:**\n\n" + "\n\n".join(references)
+
+
+def _get_section_prompt(section: PaperSection, topic: str, context: str) -> str:
+    """Generate section-specific prompt for scientific writing."""
+
+    base_instruction = f"""Du bist ein wissenschaftlicher Autor. Schreibe einen akademischen Text auf Deutsch im wissenschaftlichen Stil.
+
+WICHTIG:
+- Verwende ausschließlich den bereitgestellten Kontext als Grundlage
+- Zitiere alle verwendeten Quellen im Harvard-Stil (Autor, Jahr)
+- Schreibe objektiv, präzise und wissenschaftlich
+- Vermeide persönliche Meinungen und unwissenschaftliche Formulierungen
+- Nutze Fachterminologie angemessen
+- Strukturiere den Text logisch und kohärent
+
+Thema: {topic}
+
+Kontext aus der Literatur:
+{context}
+
+"""
+
+    section_instructions = {
+        PaperSection.ABSTRACT: """Schreibe ein prägnantes Abstract (150-250 Wörter), das:
+- Den Forschungsgegenstand/das Problem einführt
+- Die zentrale Fragestellung oder Hypothese nennt
+- Die verwendete Methodik kurz beschreibt
+- Die wichtigsten Ergebnisse zusammenfasst
+- Die Bedeutung/Implikationen der Ergebnisse aufzeigt
+
+Das Abstract sollte eigenständig verständlich sein und einen vollständigen Überblick bieten.""",
+
+        PaperSection.INTRODUCTION: """Schreibe eine fundierte Einleitung (2-3 Seiten), die:
+- Den thematischen Hintergrund und die Relevanz des Forschungsthemas darstellt
+- Den aktuellen Forschungsstand skizziert
+- Eine Forschungslücke identifiziert
+- Die zentrale Forschungsfrage oder Hypothese formuliert
+- Die Zielsetzung der Arbeit klar definiert
+- Den Aufbau der Arbeit kurz umreißt
+
+Zitiere relevante Literatur, um deine Argumentation zu stützen.""",
+
+        PaperSection.LITERATURE_REVIEW: """Schreibe eine strukturierte Literaturübersicht (3-5 Seiten), die:
+- Einen systematischen Überblick über relevante Forschungsarbeiten gibt
+- Verschiedene theoretische Ansätze und Perspektiven darstellt
+- Zentrale Konzepte, Theorien und Modelle erläutert
+- Methodische Ansätze in der Forschung vergleicht
+- Konsens und Kontroversen in der Literatur aufzeigt
+- Forschungslücken identifiziert
+- Einen theoretischen Rahmen für die eigene Arbeit etabliert
+
+Organisiere die Literatur thematisch, chronologisch oder methodisch und zitiere alle Quellen präzise.""",
+
+        PaperSection.METHODOLOGY: """Schreibe einen detaillierten Methodikteil (2-3 Seiten), der:
+- Das Forschungsdesign beschreibt (z.B. qualitativ, quantitativ, mixed methods)
+- Die Datenerhebungsmethoden erläutert
+- Die Stichprobe/das Sample beschreibt (Größe, Auswahl, Eigenschaften)
+- Die Datenanalyseverfahren detailliert darstellt
+- Verwendete Tools, Instrumente oder Software nennt
+- Gütekriterien und Limitationen reflektiert
+- Die Vorgehensweise so beschreibt, dass sie replizierbar ist
+
+Begründe methodische Entscheidungen mit Verweis auf die Literatur.""",
+
+        PaperSection.RESULTS: """Schreibe einen klaren Ergebnisteil (3-4 Seiten), der:
+- Die Forschungsergebnisse systematisch präsentiert
+- Die Daten objektiv und präzise darstellt
+- Wichtige Befunde hervorhebt
+- Tabellen, Grafiken oder Abbildungen beschreibt (falls im Kontext erwähnt)
+- Die Ergebnisse strukturiert nach Forschungsfragen oder Hypothesen
+- Quantitative Daten mit statistischen Kennwerten präsentiert
+- Qualitative Befunde mit Beispielen illustriert
+
+Interpretiere die Ergebnisse noch NICHT – bleibe deskriptiv.""",
+
+        PaperSection.DISCUSSION: """Schreibe eine kritische Diskussion (3-4 Seiten), die:
+- Die wichtigsten Ergebnisse zusammenfasst
+- Die Befunde im Kontext der bestehenden Literatur interpretiert
+- Übereinstimmungen und Widersprüche zur Forschungsliteratur aufzeigt
+- Die Forschungsfragen beantwortet
+- Theoretische und praktische Implikationen diskutiert
+- Limitationen der Studie kritisch reflektiert
+- Stärken der Arbeit herausstellt
+- Ansatzpunkte für zukünftige Forschung aufzeigt
+
+Argumentiere differenziert und zitiere relevante Literatur zur Einordnung.""",
+
+        PaperSection.CONCLUSION: """Schreibe eine prägnante Schlussfolgerung (1-2 Seiten), die:
+- Die zentralen Ergebnisse zusammenfasst
+- Die Forschungsfrage beantwortet
+- Den Beitrag zur Forschung herausstellt
+- Praktische Implikationen aufzeigt
+- Ausblick auf zukünftige Forschung gibt
+- Mit einem starken, klaren Schlusssatz endet
+
+Führe KEINE neuen Informationen ein, sondern synthetisiere die wichtigsten Erkenntnisse.""",
+    }
+
+    return base_instruction + section_instructions[section]
+
+
+def generate_scientific_section(
+    section: PaperSection,
+    topic: str,
+    num_sources: int = 8,
+) -> ScientificText:
+    """
+    Generate a scientific paper section with Harvard citations.
+
+    Args:
+        section: The type of paper section to generate
+        topic: The research topic or question
+        num_sources: Number of sources to retrieve (default: 8)
+
+    Returns:
+        ScientificText with generated text, citations, and references
+    """
+    # Retrieve relevant sources
+    query_embedding = embed_texts([topic])[0]
+    retrieved = similarity_search(query_embedding, k=num_sources)
+
+    if not retrieved:
+        return ScientificText(
+            text="Es sind keine passenden Dokumente für dieses Thema in der Datenbank vorhanden. "
+                 "Bitte laden Sie zunächst relevante wissenschaftliche Literatur hoch.",
+            citations=[],
+            sources=[],
+            reference_list="",
+        )
+
+    # Rerank sources
+    candidates = [
+        RerankCandidate(
+            doc_id=chunk.doc_id,
+            chunk_id=chunk.chunk_id,
+            content=chunk.content,
+            score=chunk.score,
+            meta=chunk.meta,
+        )
+        for chunk in retrieved
+    ]
+    ranked = rerank(topic, candidates)
+
+    # Build context with citations
+    context_parts = []
+    citations = []
+
+    for idx, item in enumerate(ranked[:num_sources], 1):
+        meta = _extract_metadata(item)
+        citation = Citation(
+            doc_id=item.doc_id,
+            chunk_id=item.chunk_id,
+            authors=meta.get('authors'),
+            year=meta.get('year'),
+        )
+        citations.append(citation)
+
+        # Add context with citation placeholder
+        context_parts.append(
+            f"[Quelle {idx}: {citation.in_text}]\n{item.content}\n"
+        )
+
+    context = "\n".join(context_parts)
+
+    # Generate the section
+    prompt = _get_section_prompt(section, topic, context)
+
+    # Call LLM
+    if settings.llm_provider == "anthropic":
+        client = _get_anthropic()
+        message = client.messages.create(
+            model=settings.llm_model,
+            max_tokens=4000,  # Longer for scientific writing
+            temperature=0.3,   # Slightly higher for more natural writing
+            messages=[{"role": "user", "content": prompt}],
+        )
+        generated_text = "".join(
+            block.text for block in message.content if hasattr(block, "text")
+        )
+    else:
+        client = _get_openai()
+        completion = client.chat.completions.create(
+            model=settings.llm_model,
+            temperature=0.3,
+            max_tokens=4000,
+            messages=[
+                {"role": "system", "content": "Du bist ein wissenschaftlicher Autor."},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        generated_text = completion.choices[0].message.content or ""
+
+    # Build reference list
+    reference_list = _build_harvard_references(citations)
+
+    # Convert retrieved to RetrievedChunk for sources
+    sources = [
+        RetrievedChunk(
+            doc_id=item.doc_id,
+            chunk_id=item.chunk_id,
+            content=item.content,
+            score=item.score,
+            meta=item.meta,
+        )
+        for item in ranked
+    ]
+
+    return ScientificText(
+        text=generated_text,
+        citations=citations,
+        sources=sources,
+        reference_list=reference_list,
+    )
+
+
+__all__ = [
+    "PaperSection",
+    "SECTION_NAMES_DE",
+    "Citation",
+    "ScientificText",
+    "generate_scientific_section",
+]


### PR DESCRIPTION
Neue Features:
- Wissenschaftliches Schreiben Modul (scientific_writing.py)
- 7 Paper-Sektionen: Abstract, Einleitung, Literaturübersicht, Methodik, Ergebnisse, Diskussion, Schlussfolgerung
- Harvard-Zitierstil mit In-Text-Zitationen und Literaturverzeichnis
- Erweiterte Streamlit-GUI mit Modus-Auswahl (Q&A vs. Wissenschaftliches Schreiben)
- Detaillierte Prompt-Templates für jede wissenschaftliche Sektion
- Anpassbare Quellenanzahl (3-15)
- Deutsche Sprache für alle generierten Texte

Technische Details:
- Integration mit bestehendem RAG-System (Retrieval, Reranking)
- Metadata-Extraktion für Zitationen (Autor, Jahr)
- Automatische Referenzlisten-Generierung
- Erweiterte max_tokens (4000) für längere wissenschaftliche Texte
- Temperature 0.3 für natürlicheren wissenschaftlichen Stil

Dokumentation:
- README aktualisiert mit wissenschaftlichem Schreib-Modus
- Workflow-Anleitung und Feature-Beschreibung hinzugefügt
- Bekannte Einschränkungen dokumentiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)